### PR TITLE
[Feat/#3] 실시간 관제 페이지 구성1

### DIFF
--- a/public/assets/marker.svg
+++ b/public/assets/marker.svg
@@ -1,0 +1,25 @@
+<svg
+  width="32"
+  height="48"
+  viewBox="0 0 32 48"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <!-- Pin body -->
+  <path
+    d="M16 0
+       C7.2 0 0 7.2 0 16
+       C0 28 16 48 16 48
+       C16 48 32 28 32 16
+       C32 7.2 24.8 0 16 0Z"
+    fill="#1E88E5"
+  />
+
+  <!-- Inner white circle -->
+  <circle
+    cx="16"
+    cy="16"
+    r="6"
+    fill="white"
+  />
+</svg>

--- a/src/app/dashboard/realTimeControl/components/realtimecontrollayout.tsx
+++ b/src/app/dashboard/realTimeControl/components/realtimecontrollayout.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 import { RealTimeInfoPanel } from './realtimeinfopanel';
 import { RealTimeMap } from './realtimemap';
@@ -8,9 +9,9 @@ import { RealTimeMap } from './realtimemap';
 export function RealTimeControlLayout(): React.JSX.Element {
 	return (
 		<Stack
-			spacing={3}
+			spacing={2}
 			sx={{
-				mt: -2,
+				mt: -5,
 				width: 'calc(100vw - 80px)',
 				mx: 'calc(50% - 50vw + 40px)',
 				'@media (min-width:600px)': {
@@ -23,6 +24,9 @@ export function RealTimeControlLayout(): React.JSX.Element {
 				},
 			}}
 		>
+			<Typography sx={{ fontSize: 30, fontWeight: 800}}>
+				실시간 관제
+			</Typography>
 			<Box
 				sx={{
 					height: 600,

--- a/src/app/dashboard/realTimeControl/components/realtimecontrollayout.tsx
+++ b/src/app/dashboard/realTimeControl/components/realtimecontrollayout.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+
+import { RealTimeInfoPanel } from './realtimeinfopanel';
+import { RealTimeMap } from './realtimemap';
+
+export function RealTimeControlLayout(): React.JSX.Element {
+	return (
+		<Stack
+			spacing={3}
+			sx={{
+				mt: -2,
+				width: 'calc(100vw - 80px)',
+				mx: 'calc(50% - 50vw + 40px)',
+				'@media (min-width:600px)': {
+					width: 'calc(100vw - 80px)',
+					mx: 'calc(50% - 50vw + 40px)',
+				},
+				'@media (min-width:1200px)': {
+					width: 'calc(100vw - var(--SideNav-width) - 80px)',
+					mx: 'calc(50% - (100vw - var(--SideNav-width)) / 2 + 40px)',
+				},
+			}}
+		>
+			<Box
+				sx={{
+					height: 600,
+					width: '100%',
+					overflow: 'hidden',
+					borderRadius: 3,
+					border: '1px solid',
+					borderColor: 'grey.200',
+					bgcolor: 'common.white',
+					boxShadow: 1,
+				}}
+			>
+				<RealTimeMap />
+			</Box>
+			<RealTimeInfoPanel />
+		</Stack>
+	);
+}

--- a/src/app/dashboard/realTimeControl/components/realtimeinfopanel.tsx
+++ b/src/app/dashboard/realTimeControl/components/realtimeinfopanel.tsx
@@ -19,6 +19,12 @@ export function RealTimeInfoPanel(): React.JSX.Element {
 				}}
 			>
 				<Box>
+					<Box
+						component="img"
+						src="/assets/marker.svg"
+						alt="쿨링포그 설치 위치"
+						sx={{ width: 80, height: 90, mx: 'auto', mb: 5 }}
+					/>
 					<Typography variant="h6" sx={{ fontWeight: 700 }}>
 						선택된 쿨링포그 위치가 없습니다.
 					</Typography>

--- a/src/app/dashboard/realTimeControl/components/realtimeinfopanel.tsx
+++ b/src/app/dashboard/realTimeControl/components/realtimeinfopanel.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import Typography from '@mui/material/Typography';
+
+export function RealTimeInfoPanel(): React.JSX.Element {
+	return (
+		<Card sx={{ borderRadius: 3, border: '1px solid', borderColor: 'grey.200', boxShadow: 1 }}>
+			<Box
+				sx={{
+					minHeight: 620,
+					width: '100%',
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					px: 3,
+					py: 5,
+					textAlign: 'center',
+				}}
+			>
+				<Box>
+					<Typography variant="h6" sx={{ fontWeight: 700 }}>
+						선택된 쿨링포그 위치가 없습니다.
+					</Typography>
+					<Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+						조회하고 싶은 쿨링포그 위치를 지도에서 선택해주세요
+					</Typography>
+				</Box>
+			</Box>
+		</Card>
+	);
+}

--- a/src/app/dashboard/realTimeControl/components/realtimemap.tsx
+++ b/src/app/dashboard/realTimeControl/components/realtimemap.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from 'react';
+import Script from 'next/script';
+
+declare global {
+	interface Window {
+		naver?: any;
+	}
+}
+
+const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 };
+
+export function RealTimeMap(): React.JSX.Element {
+	const mapContainerRef = React.useRef<HTMLDivElement | null>(null);
+	const mapRef = React.useRef<any | null>(null);
+	const [isScriptReady, setIsScriptReady] = React.useState(false);
+
+	const clientId = process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID;
+
+	React.useEffect(() => {
+		if (!isScriptReady) return;
+		if (!mapContainerRef.current) return;
+		if (!window.naver?.maps) return;
+		if (mapRef.current) return;
+
+		const map = new window.naver.maps.Map(mapContainerRef.current, {
+			center: new window.naver.maps.LatLng(DEFAULT_CENTER.lat, DEFAULT_CENTER.lng),
+			zoom: 13,
+		});
+
+		mapRef.current = map;
+	}, [isScriptReady]);
+
+	return (
+		<div style={{ position: 'relative', height: '100%', width: '100%' }}>
+			{clientId ? (
+				<Script
+					src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${clientId}`}
+					strategy="afterInteractive"
+					onReady={() => setIsScriptReady(true)}
+				/>
+			) : null}
+			<div ref={mapContainerRef} style={{ height: '100%', width: '100%' }} />
+		</div>
+	);
+}
+

--- a/src/app/dashboard/realTimeControl/components/realtimemap.tsx
+++ b/src/app/dashboard/realTimeControl/components/realtimemap.tsx
@@ -2,6 +2,10 @@
 
 import * as React from 'react';
 import Script from 'next/script';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+import { cfmarkers } from '@/dummydata/cfmarkers';
 
 declare global {
 	interface Window {
@@ -29,6 +33,13 @@ export function RealTimeMap(): React.JSX.Element {
 			zoom: 13,
 		});
 
+		cfmarkers.forEach((marker) => {
+			new window.naver.maps.Marker({
+				position: new window.naver.maps.LatLng(marker.lat, marker.lng),
+				map,
+			});
+		});
+
 		mapRef.current = map;
 	}, [isScriptReady]);
 
@@ -42,7 +53,33 @@ export function RealTimeMap(): React.JSX.Element {
 				/>
 			) : null}
 			<div ref={mapContainerRef} style={{ height: '100%', width: '100%' }} />
+			<Box
+				sx={{
+					position: 'absolute',
+					top: 16,
+					left: 16,
+					zIndex: 10,
+					bgcolor: 'rgba(255,255,255,0.9)',
+					borderRadius: 2,
+					px: 1.5,
+					py: 1,
+					boxShadow: 1,
+					pointerEvents: 'none',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 1,
+				}}
+			>
+				<Box
+					component="img"
+					src="/assets/marker.svg"
+					alt="쿨링포그 설치 위치"
+					sx={{ width: 16, height: 16 }}
+				/>
+				<Typography sx={{ fontSize: 16, fontWeight: 700 }}>
+					쿨링포그 설치 위치
+				</Typography>
+			</Box>
 		</div>
 	);
 }
-

--- a/src/app/dashboard/realTimeControl/page.tsx
+++ b/src/app/dashboard/realTimeControl/page.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+import * as React from 'react';
+
+import { RealTimeControlLayout } from '@/app/dashboard/realTimeControl/components/realtimecontrollayout';
 
 export default function Page(): React.JSX.Element {
-	return (
-		<div>실시간 관제 페이지입니다.</div>
-	);
+	return <RealTimeControlLayout />;
 }

--- a/src/dummydata/cfmarkers.ts
+++ b/src/dummydata/cfmarkers.ts
@@ -1,0 +1,38 @@
+export type CfMarker = {
+	cf_cd: string;
+	lat: number;
+	lng: number;
+};
+
+export const cfmarkers: CfMarker[] = [
+	{ cf_cd: 'CF0001', lat: 37.6027, lng: 126.9291 },
+	{ cf_cd: 'CF0002', lat: 37.5683, lng: 126.8972 },
+	{ cf_cd: 'CF0003', lat: 37.5663, lng: 126.9014 },
+	{ cf_cd: 'CF0004', lat: 37.5717, lng: 126.9769 },
+	{ cf_cd: 'CF0005', lat: 37.5735, lng: 126.9792 },
+	{ cf_cd: 'CF0006', lat: 37.5744, lng: 127.0395 },
+	{ cf_cd: 'CF0007', lat: 37.5634, lng: 127.0369 },
+	{ cf_cd: 'CF0008', lat: 37.5324, lng: 126.9902 },
+	{ cf_cd: 'CF0009', lat: 37.5219, lng: 126.9246 },
+	{ cf_cd: 'CF0010', lat: 37.5265, lng: 126.8965 },
+	{ cf_cd: 'CF0011', lat: 37.5509, lng: 126.8495 },
+	{ cf_cd: 'CF0012', lat: 37.4954, lng: 126.8874 },
+	{ cf_cd: 'CF0013', lat: 37.4569, lng: 126.8955 },
+	{ cf_cd: 'CF0014', lat: 37.4781, lng: 126.9516 },
+	{ cf_cd: 'CF0015', lat: 37.4837, lng: 127.0326 },
+	{ cf_cd: 'CF0016', lat: 37.5172, lng: 127.0473 },
+	{ cf_cd: 'CF0017', lat: 37.5145, lng: 127.1066 },
+	{ cf_cd: 'CF0018', lat: 37.515, lng: 127.073 },
+	{ cf_cd: 'CF0019', lat: 37.5303, lng: 127.1237 },
+	{ cf_cd: 'CF0020', lat: 37.6553, lng: 127.0567 },
+	{ cf_cd: 'CF0021', lat: 37.6688, lng: 127.0471 },
+	{ cf_cd: 'CF0022', lat: 37.6398, lng: 127.0256 },
+	{ cf_cd: 'CF0023', lat: 37.5894, lng: 127.0167 },
+	{ cf_cd: 'CF0024', lat: 37.6066, lng: 127.0927 },
+	{ cf_cd: 'CF0025', lat: 37.5385, lng: 127.0822 },
+	{ cf_cd: 'CF0026', lat: 37.5638, lng: 126.9976 },
+	{ cf_cd: 'CF0027', lat: 37.5793, lng: 126.9368 },
+	{ cf_cd: 'CF0028', lat: 37.6122, lng: 127.0304 },
+	{ cf_cd: 'CF0029', lat: 37.4847, lng: 126.9296 },
+	{ cf_cd: 'CF0030', lat: 37.4812, lng: 126.9527 },
+];


### PR DESCRIPTION
## Related issue 🛠
- closed #3 

## Work Description ✏️
- 실시간 관제페이지 쿨링포그 위치 선택 전 화면 구현

## Screenshot 📸
<img width="956" height="472" alt="image" src="https://github.com/user-attachments/assets/bd58d0d0-937d-4426-a70a-d74afcc320d9" />

## Uncompleted Tasks 😅
- [ ] 이후 마커 선택시 하단에 쿨링포그 정보 띄우는 작업 진행예정입니다.

## To Reviewers 📢