### PR TITLE
Feat/#25 AI 최적 위치 페이지와 예산 시뮬레이션 페이지 UI 변경 작업

### DIFF
--- a/src/app/dashboard/AIBestLocation/components/card/card-slider.tsx
+++ b/src/app/dashboard/AIBestLocation/components/card/card-slider.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+
+export default function CardSlider({
+                                     children,
+                                     cardWidth = 425,
+                                     gap = 16,
+                                   }: {
+  children: React.ReactNode;
+  cardWidth?: number;
+  gap?: number;
+}) {
+  const railRef = React.useRef<HTMLDivElement | null>(null);
+
+  // ✅ null 포함 + 배열 타입 명확히
+  const itemRefs = React.useRef<Array<HTMLDivElement | null>>([]);
+
+  const [maxH, setMaxH] = React.useState<number | null>(null);
+
+  const items = React.useMemo(() => React.Children.toArray(children), [children]);
+
+  // ✅ children 개수 바뀌면 refs 길이도 정리(안전)
+  React.useEffect(() => {
+    itemRefs.current = itemRefs.current.slice(0, items.length);
+  }, [items.length]);
+
+  React.useLayoutEffect(() => {
+    const el = railRef.current;
+    if (!el) return;
+
+    const measure = () => {
+      let h = 0;
+      for (const node of itemRefs.current) {
+        if (!node) continue;
+        h = Math.max(h, node.getBoundingClientRect().height);
+      }
+      setMaxH(h || null);
+    };
+
+    measure();
+
+    const ro = new ResizeObserver(measure);
+    for (const n of itemRefs.current) if (n) ro.observe(n);
+    ro.observe(el);
+
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [items.length]);
+
+  const nearestIndex = React.useCallback(() => {
+    const el = railRef.current;
+    if (!el) return 0;
+
+    const cx = el.scrollLeft + el.clientWidth / 2;
+
+    let best = 0;
+    let bestDist = Infinity;
+
+    itemRefs.current.forEach((node, i) => {
+      if (!node) return;
+      const left = node.offsetLeft;
+      const w = node.offsetWidth;
+      const center = left + w / 2;
+      const d = Math.abs(center - cx);
+      if (d < bestDist) {
+        bestDist = d;
+        best = i;
+      }
+    });
+
+    return best;
+  }, []);
+
+  const scrollToIndex = React.useCallback((idx: number) => {
+    const el = railRef.current;
+    const node = itemRefs.current[idx];
+    if (!el || !node) return;
+
+    const target = node.offsetLeft + node.offsetWidth / 2 - el.clientWidth / 2;
+    el.scrollTo({ left: target, behavior: 'smooth' });
+  }, []);
+
+  React.useEffect(() => {
+    const el = railRef.current;
+    if (!el) return;
+
+    let t: number | undefined;
+
+    const onScroll = () => {
+      if (t) window.clearTimeout(t);
+      t = window.setTimeout(() => scrollToIndex(nearestIndex()), 90);
+    };
+
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      if (t) window.clearTimeout(t);
+      el.removeEventListener('scroll', onScroll);
+    };
+  }, [nearestIndex, scrollToIndex]);
+
+  const prev = () => scrollToIndex(Math.max(0, nearestIndex() - 1));
+  const next = () => scrollToIndex(Math.min(items.length - 1, nearestIndex() + 1));
+
+  const sidePad = `calc(50% - ${cardWidth / 2}px)`;
+
+  return (
+    <Box sx={{ position: 'relative', borderRadius: 3, overflow: 'hidden' }}>
+      <IconButton
+        onClick={prev}
+        sx={{
+          position: 'absolute',
+          left: 8,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          zIndex: 2,
+          bgcolor: 'background.paper',
+          border: '1px solid',
+          borderColor: 'divider',
+          boxShadow: 'none',
+          '&:hover': { bgcolor: 'background.paper' },
+        }}
+      >
+        <ChevronLeftIcon />
+      </IconButton>
+
+      <IconButton
+        onClick={next}
+        sx={{
+          position: 'absolute',
+          right: 8,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          zIndex: 2,
+          bgcolor: 'background.paper',
+          border: '1px solid',
+          borderColor: 'divider',
+          boxShadow: 'none',
+          '&:hover': { bgcolor: 'background.paper' },
+        }}
+      >
+        <ChevronRightIcon />
+      </IconButton>
+
+      {/* 레일 */}
+      <Box
+        ref={railRef}
+        sx={{
+          display: 'flex',
+          alignItems: 'stretch',
+          gap: `${gap}px`,
+          overflowX: 'auto',
+          scrollSnapType: 'x mandatory',
+          scrollPaddingInline: sidePad,
+          px: sidePad,
+          py: 1,
+          '&::-webkit-scrollbar': { display: 'none' },
+          scrollbarWidth: 'none',
+        }}
+      >
+        {items.map((child, i) => (
+          <Box
+            key={i}
+            // ✅ 여기서 "return" 절대 안 함 (블록 바디)
+            ref={(node: HTMLDivElement | null) => {
+              itemRefs.current[i] = node;
+            }}
+            sx={{
+              flex: '0 0 auto',
+              width: cardWidth,
+              scrollSnapAlign: 'center',
+              display: 'flex',
+              minHeight: maxH ? `${maxH}px` : undefined,
+            }}
+          >
+            <Box sx={{ flex: 1, display: 'flex' }}>{child}</Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/app/dashboard/AIBestLocation/components/card/map-card.tsx
+++ b/src/app/dashboard/AIBestLocation/components/card/map-card.tsx
@@ -4,7 +4,8 @@ import { useEffect, useRef, useState } from 'react';
 import Script from 'next/script';
 import Box from '@mui/material/Box';
 
-import type { RecoLocItem } from '../../../../../types/AIBestLocation/reco';
+import type { RecoLocItem } from '@/types/AIBestLocation/reco';
+import * as React from "react";
 
 type MapCardProps = {
   height: number;
@@ -63,6 +64,32 @@ export default function MapCard({ height, points }: MapCardProps) {
         strategy="afterInteractive"
         onLoad={() => setLoaded(true)}
       />
+
+      {/* ✅ 좌측 상단 오버레이 */}
+      <Box
+        sx={{
+          position: 'absolute',
+          top: 12,
+          left: 12,
+          zIndex: 8, // 지도/마커 위로
+          px: 1.5,
+          py: 0.75,
+          borderRadius: 999,
+          bgcolor: '#fff',
+          boxShadow: 2,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
+          fontWeight: 700,
+          fontSize: 14,
+          lineHeight: 1,
+        }}
+      >
+        {/* 아이콘이 필요하면 이미지/아이콘 추가 */}
+        <Box component="img" src="/assets/marker.svg" alt="AI 쿨링포그 위치 추천" sx={{ width: 16, height: 16 }} />
+        쿨링포그 위치 추천
+      </Box>
+
       <Box ref={mapRef} sx={{ width: '100%', height: '100%' }} />
     </Box>
   );
@@ -74,7 +101,7 @@ export default function MapCard({ height, points }: MapCardProps) {
 function makeMarkerHTML(rank: number) {
   return `
     <div style="position:relative;width:36px;height:36px;transform:translate(-50%,-100%);">
-      <img src="${MARKER_IMG}" style="width:36px;height:36px;display:block;" />
+      <img src="${MARKER_IMG}" style="width:36px;height:36px;display:block;" alt="No image"/>
       <div style="
         position:absolute;
         top:2px;               /* 숫자 높이 조절 포인트 */

--- a/src/app/dashboard/AIBestLocation/components/card/result-card.tsx
+++ b/src/app/dashboard/AIBestLocation/components/card/result-card.tsx
@@ -6,14 +6,21 @@ import Paper from '@mui/material/Paper';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 
-import type { RecoLocItem } from '../../../../../types/AIBestLocation/reco';
+import type { RecoLocItem } from '@/types/AIBestLocation/reco';
 
 const formatNumber = (n: number) => n.toLocaleString('ko-KR');
 
 export default function ResultCard({ item }: { item: RecoLocItem }): React.JSX.Element {
   return (
-    <Paper variant="outlined" sx={{ borderRadius: 2, p: 2.5 }}>
+    <Paper variant="outlined" sx={{
+      width: '420px',
+      height: '100%',
+      borderRadius: 2,
+      p: 2.5,
+      background: 'linear-gradient(90deg, #27C1C3 0%, #4ED6B8 100%)',
+      boxShadow: '0 4px 12px rgba(39, 193, 195, 0.35)', }}>
         {/* 상단 헤더 */}
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -21,11 +28,21 @@ export default function ResultCard({ item }: { item: RecoLocItem }): React.JSX.E
               label={`${item.reco_loc_rank}위`}
               sx={{ bgcolor: '#4A60DD', color: 'white', fontWeight: 900, borderRadius: 1.5 }}
             />
-            <Chip
-              label="AI 추천"
-              variant="outlined"
-              sx={{ borderColor: '#90caf9', color: '#1e88e5', fontWeight: 800 }}
-            />
+            <Box
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                px: 1.5,
+                py: 1,
+                background: 'linear-gradient(90deg, #0B1220 0%, #0F2A3A 15%, #123B4D 100%)',
+                color: "white",
+                fontWeight: 450,
+                borderRadius: 3, // ✅ 모서리
+                lineHeight: 1,
+              }}
+            >
+              AI 추천
+            </Box>
           </Box>
 
           {item.reco_loc_tag ? (
@@ -49,29 +66,22 @@ export default function ResultCard({ item }: { item: RecoLocItem }): React.JSX.E
             gap: 1.5,
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 700 }}>
-              일 유동인구
-            </Typography>
-            <Typography variant="body1" sx={{ fontWeight: 900 }}>
-              {formatNumber(item.float_popu)}명
-            </Typography>
-          </Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Typography variant="body2" color="text.secondary" fontWeight={700}>일 유동인구</Typography>
+            <Typography fontWeight={900}>{formatNumber(item.float_popu)}명</Typography>
+          </Stack>
 
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 700 }}>
-              취약성 지수
-            </Typography>
-            <Typography variant="body1" sx={{ fontWeight: 900 }}>
-              {formatNumber(item.reco_loc_risk)}점
-            </Typography>
-          </Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Typography variant="body2" color="text.secondary" fontWeight={700}>취약성 지수</Typography>
+            <Typography fontWeight={900}>{formatNumber(item.reco_loc_risk)}점</Typography>
+          </Stack>
+
         </Box>
 
         <Divider sx={{ my: 2 }} />
 
         {/* 추천 사유 */}
-        <Box sx={{ bgcolor: '#f7fbff', border: '1px solid #d6e9ff', borderRadius: 2, p: 2 }}>
+        <Box sx={{ bgcolor: '#f7fbff', border: '1px solid #d6e9ff', borderRadius: 2, p: 2, height: '57%' }}>
           <Typography sx={{ fontWeight: 900, color: '#1565c0', mb: 1 }}>
             AI 추천 사유
           </Typography>

--- a/src/app/dashboard/AIBestLocation/components/card/state-card.tsx
+++ b/src/app/dashboard/AIBestLocation/components/card/state-card.tsx
@@ -17,6 +17,7 @@ export default function StateCard({
     <Paper
 			variant="outlined"
       sx={{
+        background: 'linear-gradient(180deg, #F7FAFF 0%, #F1F5FF 100%)',
         borderRadius: 2,
         p: 2,
         transition: (theme) => theme.transitions.create('box-shadow'),

--- a/src/app/dashboard/AIBestLocation/components/panel/left-panel.tsx
+++ b/src/app/dashboard/AIBestLocation/components/panel/left-panel.tsx
@@ -3,20 +3,17 @@
 import * as React from "react";
 import Paper from "@mui/material/Paper";
 import Button from "@mui/material/Button";
-import FormControlLabel from "@mui/material/FormControlLabel";
 import IconButton from "@mui/material/IconButton";
 import InputAdornment from "@mui/material/InputAdornment";
 import MenuItem from "@mui/material/MenuItem";
-import Radio from "@mui/material/Radio";
-import RadioGroup from "@mui/material/RadioGroup";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import { region_map } from "../../../data/AIBestLocation/region-map";
-
-// import type { RecoRequestBody } from "../../types/reco";
 import Box from "@mui/material/Box";
-import type { RecoRequestBody } from "../../../../../types/AIBestLocation/reco";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+
+import { region_map } from "@/app/dashboard/data/AIBestLocation/region-map";
+import type { RecoRequestBody } from "@/types/AIBestLocation/reco";
 
 const clampCount = (n: number) => Math.min(5, Math.max(1, Math.floor(n)));
 
@@ -28,6 +25,49 @@ type Props = {
   isLoading: boolean;
 };
 
+function StepBox({
+                   title,
+                   children,
+                   width,
+                   flex,
+                 }: {
+  title: string;
+  children: React.ReactNode;
+  width?: number | string;
+  flex?: number;
+}) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, width, flex, minWidth: 0 }}>
+      <Typography variant="subtitle2" sx={{ whiteSpace: "nowrap" }}>
+        {title}
+      </Typography>
+      {children}
+    </Box>
+  );
+}
+
+function StepChevron() {
+  return (
+    <Box
+      sx={{
+        alignSelf: "flex-end",
+        mb: "4px",
+        mx: 0.75,
+        width: 32,
+        height: 32,
+        borderRadius: "999px",
+        bgcolor: "action.hover",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flex: "0 0 auto",
+      }}
+    >
+      <ChevronRightIcon sx={{ fontSize: 22, color: "text.secondary" }} />
+    </Box>
+  );
+}
+
 export default function LeftPanel({
                                     headerHeight,
                                     value,
@@ -38,122 +78,184 @@ export default function LeftPanel({
   const districts = Object.keys(region_map);
   const neighborhoods = value.target_region_gu ? (region_map[value.target_region_gu] ?? []) : [];
 
-  const handleDecrease = () => onChangeAction({ target_count: clampCount(value.target_count - 1) });
-  const handleIncrease = () => onChangeAction({ target_count: clampCount(value.target_count + 1) });
+  const handleDecrease = () =>
+    onChangeAction({ target_count: clampCount(value.target_count - 1) });
+  const handleIncrease = () =>
+    onChangeAction({ target_count: clampCount(value.target_count + 1) });
+
+  // 공통: TextField를 더 컴팩트하게
+  const compactTfSx = {
+    "& .MuiInputBase-root": { height: 44 }, // 기본 56 -> 44로 축소
+    "& .MuiInputBase-input": { py: 0.75 },
+  };
 
   return (
-    <Box
+    <Paper
+      elevation={4}
       sx={{
-        flex: 2.7,
-        position: { md: "sticky" },
-        top: { md: `${headerHeight + 16}px` },
-        alignSelf: { md: "flex-start" },
-        maxHeight: { md: `calc(100vh - ${headerHeight}px - 32px)` },
+        border: "1px solid  #E3E8F2",
+        borderRadius: 2,
+        p: 2.2,
+        overflowX: "hidden", // ✅ 가로 스크롤 금지
+        // ✅ headerHeight 사용(미사용 경고 제거) + 화면에서 패널이 넘치지 않도록
+        maxHeight: `calc(100dvh - ${headerHeight}px - 24px)`,
+        overflowY: "auto",
       }}
     >
-      <Paper elevation={4} sx={{ height: "100%", display: "flex", flexDirection: "column", borderRadius: 2, p: 3, overflow: 'auto' }}>
-          <Stack spacing={3} sx={{ minHeight: 0 }}>
-            <Typography variant="h6">설치 목표 기반 쿨링포그 위치 추천</Typography>
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="flex-start"
+        sx={{
+          width: "100%",
+          minWidth: 0,
+        }}
+      >
+        {/* 1 */}
+        <StepBox title="1. 설치 목표 위치 개수" width={170}>
+          <TextField
+            fullWidth
+            size="small"
+            sx={compactTfSx}
+            type="number"
+            value={value.target_count}
+            onChange={(event) => {
+              const n = Number(event.target.value);
+              onChangeAction({ target_count: clampCount(Number.isNaN(n) ? 1 : n) });
+            }}
+            slotProps={{
+              htmlInput: { min: 1, max: 5 },
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <IconButton onClick={handleDecrease} disabled={value.target_count <= 1 || isLoading}>
+                      -
+                    </IconButton>
+                  </InputAdornment>
+                ),
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Stack direction="row" spacing={0.75} alignItems="center">
+                      <Typography variant="body2" sx={{ whiteSpace: "nowrap" }}>
+                        개소
+                      </Typography>
+                      <IconButton onClick={handleIncrease} disabled={value.target_count >= 5 || isLoading}>
+                        +
+                      </IconButton>
+                    </Stack>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+        </StepBox>
 
-            <Stack spacing={1.5}>
-              <Typography variant="subtitle2">A-1. 설치 목표 위치 개수 (필수)</Typography>
-              <TextField
-                type="number"
-                value={value.target_count}
-                onChange={(event) => {
-                  const n = Number(event.target.value);
-                  onChangeAction({ target_count: clampCount(Number.isNaN(n) ? 1 : n) });
-                }}
-                slotProps={{
-                  htmlInput: { min: 1, max: 5 },
-                  input: {
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <IconButton onClick={handleDecrease} disabled={value.target_count <= 1 || isLoading}>
-                          -
-                        </IconButton>
-                      </InputAdornment>
-                    ),
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <Typography variant="body2">개소</Typography>
-                          <IconButton onClick={handleIncrease} disabled={value.target_count >= 5 || isLoading}>
-                            +
-                          </IconButton>
-                        </Stack>
-                      </InputAdornment>
-                    ),
-                  },
-                }}
-              />
-            </Stack>
+        <StepChevron />
 
-            <Stack spacing={1.5}>
-              <Typography variant="subtitle2">A-2. 지역 선택 (선택)</Typography>
-              <Typography variant="body2" color="text.secondary">
-                미선택 시 전체 지역을 대상으로 분석합니다.
-              </Typography>
-
-              <TextField
-                select
-                label="행정구 선택"
-                value={value.target_region_gu}
-                onChange={(event) => {
-                  onChangeAction({
-                    target_region_gu: event.target.value,
-                    target_region_dong: "",
-                  });
-                }}
-                disabled={isLoading}
-              >
-                <MenuItem value="">미선택</MenuItem>
-                {districts.map((gu) => (
-                  <MenuItem key={gu} value={gu}>
-                    {gu}
-                  </MenuItem>
-                ))}
-              </TextField>
-
-              <TextField
-                select
-                label="행정동 선택"
-                value={value.target_region_dong}
-                onChange={(event) => onChangeAction({ target_region_dong: event.target.value })}
-                disabled={!value.target_region_gu || isLoading}
-              >
-                <MenuItem value="">미선택</MenuItem>
-                {neighborhoods.map((dong) => (
-                  <MenuItem key={dong} value={dong}>
-                    {dong}
-                  </MenuItem>
-                ))}
-              </TextField>
-            </Stack>
-
-            <Stack spacing={1.5}>
-              <Typography variant="subtitle2">A-3. 우선순위 옵션</Typography>
-              <RadioGroup
-                value={value.reco_loc_type_cd}
-                onChange={(event) => onChangeAction({ reco_loc_type_cd: Number(event.target.value) as 1 | 2 | 3 })}
-              >
-                <FormControlLabel value={1} control={<Radio />} label="취약계층 보호 우선" />
-                <FormControlLabel value={2} control={<Radio />} label="유동 인구 우선" />
-                <FormControlLabel value={3} control={<Radio />} label="체감 온도 저감 우선" />
-              </RadioGroup>
-            </Stack>
-
-            <Button
-              variant="contained"
-              fullWidth
-              sx={{ mt: "auto", bgcolor: "#4A60DD", "&:hover": { bgcolor: "#2e49e1" } }}
-              onClick={onSubmitAction}
+        {/* 2 */}
+        <StepBox title="2. 지역 선택" flex={1}>
+          <Stack direction="row" spacing={1} sx={{ minWidth: 0 }}>
+            <TextField
+              select
+              size="small"
+              sx={{ ...compactTfSx, minWidth: 160, flex: 1 }}
+              value={value.target_region_gu}
+              onChange={(event) => {
+                onChangeAction({
+                  target_region_gu: event.target.value,
+                  target_region_dong: "",
+                });
+              }}
               disabled={isLoading}
+              // ✅ SelectProps(deprecated) -> slotProps.select 로 교체
+              slotProps={{
+                select: {
+                  displayEmpty: true,
+                  renderValue: (selected) => (selected ? String(selected) : "행정구 전체"),
+                },
+              }}
             >
-              AI 최적위치 추천
-            </Button>
+              <MenuItem value="">행정구 전체</MenuItem>
+              {districts.map((gu) => (
+                <MenuItem key={gu} value={gu}>
+                  {gu}
+                </MenuItem>
+              ))}
+            </TextField>
+
+            <TextField
+              select
+              size="small"
+              sx={{ ...compactTfSx, minWidth: 160, flex: 1 }}
+              value={value.target_region_dong}
+              onChange={(event) => onChangeAction({ target_region_dong: event.target.value })}
+              disabled={!value.target_region_gu || isLoading}
+              // ✅ SelectProps(deprecated) -> slotProps.select 로 교체
+              slotProps={{
+                select: {
+                  displayEmpty: true,
+                  renderValue: (selected) => {
+                    if (!value.target_region_gu) return "행정동 전체";
+                    return selected ? String(selected) : "행정동 전체";
+                  },
+                },
+              }}
+            >
+              <MenuItem value="">행정동 전체</MenuItem>
+              {neighborhoods.map((dong) => (
+                <MenuItem key={dong} value={dong}>
+                  {dong}
+                </MenuItem>
+              ))}
+            </TextField>
           </Stack>
-      </Paper>
-    </Box>
+        </StepBox>
+
+        <StepChevron />
+
+        {/* 3 */}
+        <StepBox title="3. 우선순위 옵션" width={240}>
+          <TextField
+            fullWidth
+            select
+            size="small"
+            sx={compactTfSx}
+            value={value.reco_loc_type_cd}
+            onChange={(event) =>
+              onChangeAction({ reco_loc_type_cd: Number(event.target.value) as 1 | 2 | 3 })
+            }
+            disabled={isLoading}
+          >
+            <MenuItem value={1}>취약계층 보호 우선</MenuItem>
+            <MenuItem value={2}>유동 인구 우선</MenuItem>
+            <MenuItem value={3}>체감 온도 저감 우선</MenuItem>
+          </TextField>
+        </StepBox>
+
+        <StepChevron />
+
+        {/* 버튼 */}
+        <Box sx={{ width: 190, display: "flex", flexDirection: "column", gap: 0.5 }}>
+          <Typography variant="subtitle2" sx={{ visibility: "hidden" }}>
+            자리맞춤
+          </Typography>
+          <Button
+            variant="contained"
+            fullWidth
+            sx={{
+              height: 44,
+              bgcolor: "#4A60DD",
+              borderRadius: 2,
+              "&:hover": { bgcolor: "#2e49e1" },
+              whiteSpace: "nowrap",
+            }}
+            onClick={onSubmitAction}
+            disabled={isLoading}
+          >
+            AI 최적위치 추천
+          </Button>
+        </Box>
+      </Stack>
+    </Paper>
   );
 }

--- a/src/app/dashboard/AIBestLocation/components/panel/right-panel.tsx
+++ b/src/app/dashboard/AIBestLocation/components/panel/right-panel.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 
-import type { RecoApiResponse, RecoRequestBody } from '../../../../../types/AIBestLocation/reco';
+import type { RecoApiResponse, RecoRequestBody } from '@/types/AIBestLocation/reco';
 
 import IdleState from '../states/idle-state';
 import LoadingOverlay from '../states/loading-overlay';
@@ -28,7 +28,13 @@ export default function RightPanel({
     data.data.result.length > 0;
 
   return (
-    <Box sx={{ flex: 7.3, minWidth: 0 }}>
+
+    <Box sx={{
+      minWidth: "100%",
+      border: "1px solid",
+      borderColor: "divider",
+      borderRadius: 2,
+      flexDirection: "column"}}>
       <Paper elevation={4} sx={{ position: 'relative', width: '100%', display: 'flex', flexDirection: 'column', gap: 2, borderRadius: 2, p: 3 }}>
           {/* ✅ 처음(또는 새로고침)에는 Idle, 검색 후에는 Result */}
           {hasResult ? (

--- a/src/app/dashboard/AIBestLocation/components/states/idle-state.tsx
+++ b/src/app/dashboard/AIBestLocation/components/states/idle-state.tsx
@@ -8,20 +8,20 @@ export default function IdleState() {
   return (
     <Box
       sx={{
-        py: 8,
+        py: 5,
         px: 2,
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
         textAlign: "center",
-        gap: 3,
+        gap: 2,
       }}
     >
       <Box
         component="img"
         src="/assets/locationIdle.svg"
         alt="idle"
-        sx={{ width: 240, maxWidth: "100%", mb: 7}}
+        sx={{ width: 180, maxWidth: "100%", mb: 2}}
       />
 
       <Typography variant="h6" sx={{ fontWeight: 900 }}>

--- a/src/app/dashboard/AIBestLocation/components/states/loading-overlay.tsx
+++ b/src/app/dashboard/AIBestLocation/components/states/loading-overlay.tsx
@@ -19,6 +19,7 @@ export default function LoadingOverlay() {
         gap: 2,
         zIndex: 20,
         backdropFilter: 'blur(2px)',
+        borderRadius: 2,
       }}
     >
       <CircularProgress />

--- a/src/app/dashboard/AIBestLocation/components/states/result-view.tsx
+++ b/src/app/dashboard/AIBestLocation/components/states/result-view.tsx
@@ -2,13 +2,13 @@
 
 import * as React from 'react';
 import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
 
-import type { RecoApiResponse, RecoRequestBody } from '../../../../../types/AIBestLocation/reco';
+import type { RecoApiResponse, RecoRequestBody } from '@/types/AIBestLocation/reco';
 
 import StateCard from '../card/state-card';
 import ResultCard from '../card/result-card';
 import MapCard from '../card/map-card';
+import CardSlider from "@/app/dashboard/AIBestLocation/components/card/card-slider";
 
 function priorityText(cd: 1 | 2 | 3) {
   if (cd === 1) return '취약계층 보호 우선';
@@ -29,13 +29,15 @@ export default function ResultView({
 
   return (
     <>
+      {/* 지도 */}
+      <MapCard height={mapHeight} points={items} />
       <Box
         sx={{
           flexShrink: 0,
           display: 'grid',
           gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' },
           gap: 3,
-					mb: 1
+          mb: 1
         }}
       >
         <StateCard label="분석 지역 범위 📉" value={data.data!.result_address} />
@@ -43,16 +45,18 @@ export default function ResultView({
         <StateCard label="가능 추천 위치 수 🌐" value={data.data!.result_count} unit="개소" />
         <StateCard label="예상 보호 인원 👨‍👦‍👦" value={25_345} unit="명" />
       </Box>
-
-      {/* 지도 */}
-      <MapCard height={mapHeight} points={items} />
-
       {/* 결과 카드 리스트 */}
-      <Stack spacing={4}>
+      <CardSlider>
         {items.map((item) => (
-          <ResultCard key={`${item.reco_loc_rank}-${item.gee_loc_adress}`} item={item} />
+          <Box
+            key={`${item.reco_loc_rank}-${item.gee_loc_adress}`}
+            sx={{ width: { xs: 260, sm: 280, md: 320 } }}
+          >
+            <ResultCard item={item} />
+          </Box>
         ))}
-      </Stack>
+      </CardSlider>
+
     </>
   );
 }

--- a/src/app/dashboard/AIBestLocation/page.tsx
+++ b/src/app/dashboard/AIBestLocation/page.tsx
@@ -4,10 +4,8 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { AiBestLocationHeader } from './components/ai-best-location-header';
-// import type { RecoApiResponse, RecoRequestBody } from './types/reco';
-import Typography from '@mui/material/Typography';
 
-import type { RecoApiResponse, RecoRequestBody } from '../../../types/AIBestLocation/reco';
+import type { RecoApiResponse, RecoRequestBody } from '@/types/AIBestLocation/reco';
 import { postReco } from './lib/api';
 
 import LeftPanel from './components/panel/left-panel';
@@ -54,35 +52,37 @@ export default function Page(): React.JSX.Element {
   };
 
   return (
-		<Container maxWidth="xl" sx={{ py: 4 }}>
-			<Stack spacing={3}>
-				<AiBestLocationHeader />
-				{/* ✅ 왼쪽 고정 + 오른쪽 스크롤 구조 */}
-				<Box
-					sx={{
-						display: 'flex',
-						alignItems: { md: 'flex-start' },
-						flexDirection: { xs: 'column', md: 'row' },
-						gap: { xs: 2, md: 2 },
-					}}
-				>
-					{/* Left (sticky) */}
-					<LeftPanel
-						headerHeight={HEADER_HEIGHT}
-						value={request}
-						onChangeAction={(next) => setRequest((prev) => ({ ...prev, ...next }))}
-						onSubmitAction={handleSubmit}
-						isLoading={isLoading}
-					/>
+		<Container maxWidth="lg" sx={{ py: 1 }}>
+      <AiBestLocationHeader />
+      <Stack spacing={2} sx={{ mt: 4 }}>
+        <Box
+          sx={{
+            position: "sticky",
+            top: `${HEADER_HEIGHT + 12}px`,
+            alignSelf: "flex-start",
+            zIndex: 10,
+            width: "100%",
+            flex: "0 0 auto",
+          }}
+        >
+          <LeftPanel
+            headerHeight={HEADER_HEIGHT}
+            value={request}
+            onChangeAction={(next) => setRequest((prev) => ({ ...prev, ...next }))}
+            onSubmitAction={handleSubmit}
+            isLoading={isLoading}
+          />
+        </Box>
 
-					{/* Right (Idle/Loading/Result) */}
-					<RightPanel
-						mapHeight={MAP_HEIGHT}
-						isLoading={isLoading}
-						request={request}
-						data={data}
-					/>
-				</Box>
+        {/* RIGHT */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <RightPanel
+            mapHeight={MAP_HEIGHT}
+            isLoading={isLoading}
+            request={request}
+            data={data}
+          />
+        </Box>
 			</Stack>
 		</Container>
   );

--- a/src/app/dashboard/budgetSimulation/components/budget-simulation-header.tsx
+++ b/src/app/dashboard/budgetSimulation/components/budget-simulation-header.tsx
@@ -32,7 +32,7 @@ export function BudgetSimulationHeader() {
 						예산 시뮬레이션
 					</Typography>
 					<Typography variant="body2" color="text.secondary">
-						품목을 선택(카드 클릭 또는 설치개수 입력)하고 운영기간/가용예산을 입력하면 예산 사용률과 남은 금액을 확인할 수 있습니다.
+            품목 선택 후 운영기간·예산을 입력하면 사용률과 잔액을 확인할 수 있습니다.
 					</Typography>
 				</Box>
 			</Box>

--- a/src/app/dashboard/budgetSimulation/page.tsx
+++ b/src/app/dashboard/budgetSimulation/page.tsx
@@ -132,25 +132,6 @@ function MoneyBlock(props: { label: string; value: number; emphasize?: boolean }
   );
 }
 
-function CostBox(props: { label: string; total: number; unitLine: string }) {
-  const { label, total, unitLine } = props;
-  return (
-    <Box sx={{ flex: 1, minWidth: 0 }}>
-      <Typography variant="overline" color="text.secondary" sx={{ fontWeight: 900, letterSpacing: "0.08em", lineHeight: 1.1 }}>
-        {label}
-      </Typography>
-
-      <Typography fontWeight={700} sx={{ mt: 0.35, lineHeight: 1.12, letterSpacing: "-0.02em" }}>
-        {formatKRW(total)}
-      </Typography>
-
-      <Typography variant="caption" color="text.secondary" sx={{ mt: 0, lineHeight: 1.2, display: "block" }}>
-        {unitLine}
-      </Typography>
-    </Box>
-  );
-}
-
 type BudgetItem = FogItem & { qty: number };
 
 export default function CoolingFogBudgetPage() {
@@ -247,11 +228,10 @@ export default function CoolingFogBudgetPage() {
   };
 
   return (
-		<Container maxWidth="xl" sx={{ py: 4 }}>
-			<Stack spacing={3}>
-				{/* Header */}
-				<BudgetSimulationHeader />
-
+		<Container maxWidth="lg" sx={{ py: 1 }}>
+      {/* Header */}
+      <BudgetSimulationHeader />
+      <Stack spacing={3} sx={{mt: 4}}>
 				{/* 2 Column */}
 				<Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems="flex-start">
 					{/* Left: Items */}
@@ -260,7 +240,7 @@ export default function CoolingFogBudgetPage() {
 							sx={{
 								display: "grid",
 								gap: 1.5,
-								gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+								gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(2, 1fr)" },
 								alignItems: "stretch",
 							}}
 						>
@@ -287,7 +267,7 @@ export default function CoolingFogBudgetPage() {
 										sx={{
 											cursor: "pointer",
 											borderRadius: UI_BORDER_RADIUS,
-											border: "1.5px solid",
+											border: "1px solid",
 											borderColor: isSelected ? "primary.main" : "divider",
 											bgcolor: isSelected ? UI_BG_ITEM_CARD_SELECTED : UI_BG_ITEM_CARD,
 											boxShadow: isSelected ? 2 : 0,
@@ -347,21 +327,64 @@ export default function CoolingFogBudgetPage() {
 										{/* Content */}
 										<Box sx={{ px: 2, pb: 2.25, flex: 1, display: "flex", flexDirection: "column" }}>
 											<Stack spacing={1.1} sx={{ flex: 1 }}>
-												<Box sx={{ minWidth: 0 }}>
-													<Typography fontWeight={900} sx={{ lineHeight: 1.2 }}>
-														{it.name}
-													</Typography>
-													<Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.35 }}>
-														추천 설치: {it.loc}
-													</Typography>
-												</Box>
+                        <RowBetween>
+                          <Typography fontWeight={900} sx={{ lineHeight: 1.2, minWidth: 0 }}>
+                            {it.name}
+                          </Typography>
 
-												<RowBetween>
-													<CostBox label="A  초기 설치비" total={initCost} unitLine={`단가 ${formatKRW(it.unitPrice)}`} />
-													<CostBox label="B  연간 운영비" total={annualCost} unitLine={`개당 ${formatKRW(annualUnit)}`} />
-												</RowBetween>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ display: "block", whiteSpace: "nowrap", textAlign: "right" }}
+                          >
+                            추천 설치: {it.loc}
+                          </Typography>
+                        </RowBetween>
 
-												<Divider sx={{ mt: 0.5 }} />
+                        <Stack spacing={1}>
+                          {/* A row */}
+                          <RowBetween>
+                            <Typography
+                              variant="overline"
+                              color="text.secondary"
+                              sx={{ fontWeight: 900, letterSpacing: "0.08em", lineHeight: 1.1 }}
+                            >
+                              A. 초기 설치비
+                            </Typography>
+
+                            <Stack spacing={0} sx={{ minWidth: 0, textAlign: "right" }}>
+                              <Typography fontWeight={700} sx={{ lineHeight: 1.12, letterSpacing: "-0.02em" }}>
+                                {formatKRW(initCost)}
+                              </Typography>
+                              <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.2, display: "block" }}>
+                                단가 {formatKRW(it.unitPrice)}
+                              </Typography>
+                            </Stack>
+                          </RowBetween>
+
+                          {/* B row */}
+                          <RowBetween>
+                            <Typography
+                              variant="overline"
+                              color="text.secondary"
+                              sx={{ fontWeight: 900, letterSpacing: "0.08em", lineHeight: 1.1 }}
+                            >
+                              B. 연간 운영비
+                            </Typography>
+
+                            <Stack spacing={0} sx={{ minWidth: 0, textAlign: "right" }}>
+                              <Typography fontWeight={700} sx={{ lineHeight: 1.12, letterSpacing: "-0.02em" }}>
+                                {formatKRW(annualCost)}
+                              </Typography>
+                              <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.2, display: "block" }}>
+                                개당 {formatKRW(annualUnit)}
+                              </Typography>
+                            </Stack>
+                          </RowBetween>
+                        </Stack>
+
+
+                        <Divider sx={{ mt: 0.5 }} />
 
 												<RowBetween>
 													<Stack direction="row" spacing={1} alignItems="center" onClick={stopClick} onKeyDown={stopKeyDown}>
@@ -441,16 +464,12 @@ export default function CoolingFogBudgetPage() {
 								);
 							})}
 						</Box>
-
-						<Typography variant="caption" color="text.secondary" sx={{ pb: 1, mt: 1.5, display: "block" }}>
-							* 연간 운영비(B)는 (월 전기세 + 월 수도세)를 12개월로 환산하여 계산되며, 전기/수도 항목을 별도로 표시하지 않습니다.
-						</Typography>
 					</Box>
 
 					{/* Right: Sticky Sidebar */}
 					<Box
 						sx={{
-							width: { xs: "100%", md: 392 },
+							width: { xs: "100%", md: 355 },
 							position: { md: "sticky" },
 							top: { md: STICKY_TOP },
 							flexShrink: 0,
@@ -601,6 +620,9 @@ export default function CoolingFogBudgetPage() {
 						</Stack>
 					</Box>
 				</Stack>
+        <Typography variant="caption" color="text.secondary">
+          * 연간 운영비(B)는 (월 전기세 + 월 수도세)를 12개월로 환산하여 계산되며, 전기/수도 항목을 별도로 표시하지 않습니다.
+        </Typography>
 			</Stack>
 		</Container>
   );

--- a/src/app/dashboard/data/AIBestLocation/ai-best-location.ts
+++ b/src/app/dashboard/data/AIBestLocation/ai-best-location.ts
@@ -1,5 +1,5 @@
 // app/dashboard/AIBestLocation/data/ai-best-location.ts
-import type { RecoApiResponse } from "../../../../types/AIBestLocation/reco";
+import type { RecoApiResponse } from "@/types/AIBestLocation/reco";
 
 /**
  * ✅ AI 최적 위치 추천 더미데이터


### PR DESCRIPTION
## Related issue 🛠
- closed #25 

## Work Description ✏️
- AI 최적 위치 UI 변경
- 예산 시뮬레이션 UI 변경 (품목 그리드 3개에서 2개로 변경

## Screenshot 📸
<img src="" width="360"/>

### AI 최적 위치 페이지
<img width="900" height="992" alt="image" src="https://github.com/user-attachments/assets/b7412437-76d1-4ab4-b8db-5c2522055ec8" />

### 예산 시뮬레이션 페이지
<img width="1323" height="1207" alt="image" src="https://github.com/user-attachments/assets/1091bca6-b3a1-4542-b6aa-62b8c90f225c" />


## Uncompleted Tasks 😅
- [ ] AI 보고서, 추천서 작업
- [ ] 컴포넌트 작업
- [ ] Footer에 이용약관, 개인정보처리방침 작업
- [ ] AI 위치 추적 API 연결 수행

## To Reviewers 📢