### PR TITLE
Feat/#30 하단 고정 푸터 생성

### DIFF
--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -5,12 +5,13 @@ import { config } from '@/config';
 import { GuestGuard } from '@/components/auth/guest-guard';
 import { Layout } from '@/components/auth/layout';
 import { SignInForm } from '@/components/auth/sign-in-form';
+import { MainFooter } from '@/components/dashboard/layout/main-footer';
 
 export const metadata = { title: `Sign in | Auth | ${config.site.name}` } satisfies Metadata;
 
 export default function Page(): React.JSX.Element {
   return (
-    <Layout>
+    <Layout footer={<MainFooter fullWidth />}>
       <GuestGuard>
         <SignInForm />
       </GuestGuard>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import GlobalStyles from '@mui/material/GlobalStyles';
 
 import { AuthGuard } from '@/components/auth/auth-guard';
 import { MainNav } from '@/components/dashboard/layout/main-nav';
+import { MainFooter } from '@/components/dashboard/layout/main-footer';
 import { SideNav } from '@/components/dashboard/layout/side-nav';
 
 interface LayoutProps {
@@ -43,6 +44,7 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
               {children}
             </Container>
           </main>
+          <MainFooter />
         </Box>
       </Box>
     </AuthGuard>

--- a/src/components/auth/layout.tsx
+++ b/src/components/auth/layout.tsx
@@ -9,9 +9,10 @@ import { DynamicLogo } from '@/components/core/logo';
 
 export interface LayoutProps {
   children: React.ReactNode;
+  footer?: React.ReactNode;
 }
 
-export function Layout({ children }: LayoutProps): React.JSX.Element {
+export function Layout({ children, footer }: LayoutProps): React.JSX.Element {
   return (
     <Box
       sx={{
@@ -30,6 +31,7 @@ export function Layout({ children }: LayoutProps): React.JSX.Element {
           <Box sx={{ maxWidth: '450px', width: '100%' }}>{children}</Box>
         </Box>
       </Box>
+      {footer}
     </Box>
   );
 }

--- a/src/components/dashboard/layout/main-footer.tsx
+++ b/src/components/dashboard/layout/main-footer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Container from "@mui/material/Container";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
+import { PrivacyLink } from "../../link/privacy-link";
+import { TermsLink } from "../../link/terms-link";
+
+export interface MainFooterProps {
+  fullWidth?: boolean;
+}
+
+export function MainFooter({ fullWidth = false }: MainFooterProps): React.JSX.Element {
+  return (
+    <Box
+      component="footer"
+      sx={{
+        borderTop: "1px solid var(--mui-palette-divider)",
+        bgcolor: "var(--mui-palette-background-paper)",
+        mt: "auto",
+      }}
+    >
+      <Container maxWidth={fullWidth ? false : "xl"} sx={{ py: 2.5, px: fullWidth ? 3 : undefined }}>
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={{ xs: 1, md: 2 }}
+          sx={{ alignItems: { xs: "flex-start", md: "center" }, justifyContent: "space-between" }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            © 2026 NoMoreChaos. All rights reserved.
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ alignItems: "center", flexWrap: "wrap", rowGap: 0.5 }}>
+            <TermsLink />
+            <Typography component="span" variant="body2" color="text.secondary">
+              |
+            </Typography>
+            <PrivacyLink />
+            <Typography component="span" variant="body2" color="text.secondary">
+              |
+            </Typography>
+            <Typography component="span" variant="body2" color="text.secondary">
+              문의: nomoreteam0408@gmail.com
+            </Typography>
+          </Stack>
+        </Stack>
+      </Container>
+    </Box>
+  );
+}

--- a/src/components/link/privacy-link.tsx
+++ b/src/components/link/privacy-link.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import Link from "@mui/material/Link";
+import { openPopup } from "@/lib/open-popup"; // 경로는 프로젝트에 맞게 조정
+
+const PRIVACY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL ?? "";
+
+export function PrivacyLink(): React.JSX.Element {
+  const handleOpen = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    openPopup(PRIVACY_URL, "privacy");
+  };
+
+  return (
+    <Link
+      href={PRIVACY_URL || "#"}
+      onClick={PRIVACY_URL ? handleOpen : undefined}
+      underline="hover"
+      color="text.secondary"
+      variant="body2"
+      sx={{ fontWeight: 600 }}
+      aria-disabled={!PRIVACY_URL}
+      tabIndex={PRIVACY_URL ? 0 : -1}
+    >
+      개인정보 처리방침
+    </Link>
+  );
+}

--- a/src/components/link/terms-link.tsx
+++ b/src/components/link/terms-link.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import Link from "@mui/material/Link";
+import { openPopup } from "@/lib/open-popup"; // 경로 조정
+
+const TERMS_URL = process.env.NEXT_PUBLIC_TERMS_URL ?? "";
+
+export function TermsLink(): React.JSX.Element {
+  const handleOpen = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    openPopup(TERMS_URL, "terms");
+  };
+
+  return (
+    <Link
+      href={TERMS_URL || "#"}
+      onClick={TERMS_URL ? handleOpen : undefined}
+      underline="hover"
+      color="text.secondary"
+      variant="body2"
+      sx={{ fontWeight: 600 }}
+      aria-disabled={!TERMS_URL}
+      tabIndex={TERMS_URL ? 0 : -1}
+    >
+      이용약관
+    </Link>
+  );
+}

--- a/src/lib/open-popup.ts
+++ b/src/lib/open-popup.ts
@@ -1,0 +1,16 @@
+export function openPopup(url: string, name: string): void {
+  const width = 720;
+  const height = 720;
+  const left = window.screenX + Math.max(0, (window.outerWidth - width) / 2);
+  const top = window.screenY + Math.max(0, (window.outerHeight - height) / 2);
+
+  const popup = window.open(
+    url,
+    name,
+    `popup=yes,width=${width},height=${height},left=${left},top=${top}`
+  );
+
+  if (!popup) {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #30 

## Work Description ✏️
- 메인 페이지들과 로그인 페이지 하단 고정 푸터 적용
- 이용 약관과 개인정보 처리방침은 새 팝업 창으로 노션 publish 링크로 설정
- 해당 URL 경로 설정은 env 파일에 지정

- NEXT_PUBLIC_TERMS_URL (이용약관)
- NEXT_PUBLIC_PRIVACY_URL(개인정보 처리방침)

## Screenshot 📸

### 로그인 하단 푸터
<img width="2549" height="1339" alt="스크린샷 2026-02-06 150258" src="https://github.com/user-attachments/assets/a5e2a95a-d26d-4c59-bce4-adfb4172f083" />

### 메인 하단 푸터
<img width="2539" height="1344" alt="스크린샷 2026-02-06 150505" src="https://github.com/user-attachments/assets/176865f2-1b2d-4466-a813-53f6ebada6a9" />

### 이용약관 팝업
<img width="2536" height="1344" alt="스크린샷 2026-02-06 150534" src="https://github.com/user-attachments/assets/2b10cc2b-72e6-4d58-b4eb-4f596dbf4cec" />

### 개인정보 처리방침 팝업
<img width="2540" height="1349" alt="스크린샷 2026-02-06 150515" src="https://github.com/user-attachments/assets/0141bc99-dee3-4eee-b363-982dfb256609" />


## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢
@Donghyeon03 @Roel4990 